### PR TITLE
add optional MAIL_SSL env var

### DIFF
--- a/lib/runtime_config.ex
+++ b/lib/runtime_config.ex
@@ -24,9 +24,9 @@ defmodule Bonfire.Mailer.RuntimeConfig do
             mail_blackhole.("MAIL_KEY")
 
           key ->
-            case System.get_env("MAIL_DOMAIN") do
+            case System.get_env("MAIL_DOMAIN") || System.get_env("HOSTNAME") do
               nil ->
-                mail_blackhole.("MAIL_DOMAIN")
+                mail_blackhole.("MAIL_DOMAIN or HOSTNAME")
 
               domain ->
                 case System.get_env("MAIL_FROM") do
@@ -53,9 +53,9 @@ defmodule Bonfire.Mailer.RuntimeConfig do
             mail_blackhole.("MAIL_SERVER")
 
           server ->
-            case System.get_env("MAIL_DOMAIN") do
+            case System.get_env("MAIL_DOMAIN") || System.get_env("HOSTNAME") do
               nil ->
-                mail_blackhole.("MAIL_DOMAIN")
+                mail_blackhole.("MAIL_DOMAIN or HOSTNAME")
 
               domain ->
                 case System.get_env("MAIL_USER") do
@@ -82,11 +82,18 @@ defmodule Bonfire.Mailer.RuntimeConfig do
                               port: String.to_integer(System.get_env("MAIL_PORT", "587")),
                               username: user,
                               password: password,
-                              tls: :always,
+                              tls: case System.get_env("MAIL_TLS") do
+                                "1"-> :always
+                                "0" -> :never
+                                _ -> :if_available
+                                end, 
                               allowed_tls_versions: [:"tlsv1.2"],
-                              ssl: System.get_env("MAIL_SSL", false),
-                              retries: 1,
-                              auth: :always,
+                              ssl: System.get_env("MAIL_SSL", "false") not in ["false", "0"],
+                              retries: String.to_integer(System.get_env("MAIL_RETRIES", "1")),
+                              auth: case System.get_env("MAIL_SMTP_AUTH") do
+                                "1"-> :always
+                                _ -> :if_available
+                                end,
                               reply_to: from
                         end
                     end

--- a/lib/runtime_config.ex
+++ b/lib/runtime_config.ex
@@ -84,7 +84,7 @@ defmodule Bonfire.Mailer.RuntimeConfig do
                               password: password,
                               tls: :always,
                               allowed_tls_versions: [:"tlsv1.2"],
-                              ssl: false,
+                              ssl: System.get_env("MAIL_SSL", false),
                               retries: 1,
                               auth: :always,
                               reply_to: from


### PR DESCRIPTION
Some mail servers require SSL, this adds an optional Environment variable (defaults to false if it's not present) for choosing whether to enable SSL connections. 